### PR TITLE
Add TVector3 helper functions

### DIFF
--- a/source/MarlinHelp/include/MarlinHelp/Root/LorentzVec.h
+++ b/source/MarlinHelp/include/MarlinHelp/Root/LorentzVec.h
@@ -1,12 +1,12 @@
-#ifndef LIB_MARLINHELP_PARTICLE_MC
-#define LIB_MARLINHELP_PARTICLE_MC 1
+#ifndef LIB_MARLINHELP_ROOT_LORENTZVEC
+#define LIB_MARLINHELP_ROOT_LORENTZVEC 1
 
 #include "TLorentzVector.h"
 
 namespace MarlinHelp {
 namespace Root {
 namespace LorentzVec {
-/** Namespace for helper functions that concern MCParticles.
+/** Namespace for helper functions that concern TLorentzVector.
  **/
   
 TLorentzVector boost_tlv(const TLorentzVector &vec, const TLorentzVector &boost_system );

--- a/source/MarlinHelp/include/MarlinHelp/Root/Vec3.h
+++ b/source/MarlinHelp/include/MarlinHelp/Root/Vec3.h
@@ -1,0 +1,25 @@
+#ifndef LIB_MARLINHELP_ROOT_VEC3
+#define LIB_MARLINHELP_ROOT_VEC3 1
+
+// includes from ROOT
+#include "TVector3.h"
+
+// Standard library
+#include <string>
+
+namespace MarlinHelp {
+namespace Root {
+namespace Vec3 {
+/** Namespace for helper functions that concern ROOT TVector3 (3D vectors).
+ **/
+
+std::string print(const TVector3 &vec);
+
+TVector3 rotate_into(const TVector3 &vec, const TVector3 &new_z,
+                     const TVector3 &other_plane_axis);
+
+} // namespace Vec3
+} // namespace Root
+} // namespace MarlinHelp
+
+#endif

--- a/source/MarlinHelp/src/MarlinHelp/Root/Vec3.cpp
+++ b/source/MarlinHelp/src/MarlinHelp/Root/Vec3.cpp
@@ -1,0 +1,36 @@
+#include <MarlinHelp/Root/Vec3.h>
+
+// Includes from ROOT
+#include "TRotation.h"
+
+namespace MarlinHelp {
+namespace Root {
+
+//------------------------------------------------------------------------------
+
+std::string Vec3::print(const TVector3 &vec) {
+  /** Print the x-y-z content of the vector.
+   **/
+  return std::to_string(vec.X()) + " " + std::to_string(vec.Y()) + " " +
+         std::to_string(vec.Z());
+}
+
+//------------------------------------------------------------------------------
+
+TVector3 Vec3::rotate_into(const TVector3 &vec, const TVector3 &new_z,
+                           const TVector3 &other_plane_axis) {
+  /** Rotate the given vector to how it looks in the coordinate system where
+   *new_z is the z axis, the new x axis lies in the plane of the new_z and the
+   *other given axis, and the sign of the y axis wrt. to the plane is positive.
+   **/
+  TRotation rotation;
+  rotation.SetZAxis(new_z, other_plane_axis);
+  rotation.Invert();
+  
+  return rotation * vec;
+}
+
+//------------------------------------------------------------------------------
+
+} // namespace Root
+} // namespace MarlinHelp

--- a/source/UnitTests/Root/test_Vec3.cpp
+++ b/source/UnitTests/Root/test_Vec3.cpp
@@ -1,0 +1,81 @@
+#include <gtest/gtest.h>
+
+#include <MarlinHelp/Root/Vec3.h>
+
+using namespace MarlinHelp::Root;
+
+//------------------------------------------------------------------------------
+
+TEST(TestVec3, TestPrint) {
+  // Test if vector printing works correctly
+  TVector3 v(1, -1, 0.5);
+
+  ASSERT_STREQ(Vec3::print(v).c_str(), "1.000000 -1.000000 0.500000");
+}
+
+//------------------------------------------------------------------------------
+
+TEST(TestVec3, TestRotationZ) {
+  // Test if rotation by simple moving of Z works
+  TVector3 v1(1, 0, 0);
+  TVector3 v2(0, 1, 0);
+  TVector3 v3(0, 0, 1);
+
+  struct RotRes {
+    // Set of rotation and expected result
+    std::string name;
+    TVector3 new_z;
+    TVector3 other_axis;
+    TVector3 pred_v1_rot;
+    TVector3 pred_v2_rot;
+    TVector3 pred_v3_rot;
+  };
+
+  std::vector<RotRes> tests{
+      RotRes{"trivial",         //
+             TVector3(0, 0, 1), // Rotate so that new z is y axis
+             TVector3(1, 0, 0), // Keep x where it is (in the xz plane)
+             v1, v2, v3},
+      RotRes{
+          "Z rotation",      //
+          TVector3(0, 1, 0), // Rotate so that new z is y axis
+          TVector3(1, 0, 0), // Keep x where it is (in the xz plane)
+          v1,                // Results expected by drawing this on paper
+          TVector3(0, 0, 1), //
+          TVector3(0, -1, 0) //
+      },
+      RotRes{
+          "X rotation",         //
+          TVector3(0, 0, 1),    // Keep z axis
+          TVector3(0, 2, -0.5), // new x axis in x-y plane (expect in on y axis)
+          TVector3(0, -1, 0),   // Results expected by drawing this on paper
+          TVector3(1, 0, 0),    //
+          v3                    //
+      },
+      RotRes{
+          "Switch",           // x' is former z, z' is former x
+          TVector3(1, 0, 0), // New z axis
+          TVector3(0, 0, 1),  //
+          TVector3(0, 0, 1),  //
+          TVector3(0, -1, 0), //
+          TVector3(1, 0, 0)   //
+      }};
+
+  for (const auto &test : tests) {
+    auto res_v1_rot = Vec3::rotate_into(v1, test.new_z, test.other_axis);
+    auto res_v2_rot = Vec3::rotate_into(v2, test.new_z, test.other_axis);
+    auto res_v3_rot = Vec3::rotate_into(v3, test.new_z, test.other_axis);
+
+    EXPECT_EQ(res_v1_rot, test.pred_v1_rot)
+        << test.name << " Pred: " << Vec3::print(test.pred_v1_rot)
+        << " Res: " << Vec3::print(res_v1_rot);
+    EXPECT_EQ(res_v2_rot, test.pred_v2_rot)
+        << test.name << " Pred: " << Vec3::print(test.pred_v2_rot)
+        << " Res: " << Vec3::print(res_v2_rot);
+    EXPECT_EQ(res_v3_rot, test.pred_v3_rot)
+        << test.name << " Pred: " << Vec3::print(test.pred_v3_rot)
+        << " Res: " << Vec3::print(res_v3_rot);
+  }
+}
+
+//------------------------------------------------------------------------------


### PR DESCRIPTION
- Clean up old documentation in LorentzVec header.
- Add TVector3 helper functions for printing and rotation a TVector3 object.
- Add tests for TVector3 helper functions.